### PR TITLE
HH-193449. bump Android version to >= 117

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,5 @@ module.exports = [
     'last 1 ChromeAndroid version', // всегда возвращает последнюю версию, сравнение версий работает только для десктопного Chrome
     'last 10 Edge versions',
     'Firefox ESR',
-    'Android >= 5',
+    'Android >= 117'
 ];


### PR DESCRIPTION
[Задача](https://jira.hh.ru/browse/HH-193449)

при сборке с темой магритт начала падать сборка (см скриншот), по [can i use ](https://caniuse.com/?search=ES6%20Template%20Literals)определили что проблема с версией android. Было принято решение поднять с "Android >= 5" до "Android >=117"


<img width="967" alt="image" src="https://github.com/hhru/browserslist-config-hhru/assets/33131980/f4be5cb4-ad9f-46e4-a7cd-7a6655f7fdf3">
